### PR TITLE
Shelter pets index

### DIFF
--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -1,5 +1,10 @@
 class PetsController < ApplicationController
   def index
-    @pets = Pet.all
+    if params[:shelter_id]
+      @shelter = Shelter.find(params[:shelter_id])
+      @pets = @shelter.pets
+    else
+      @pets = Pet.all
+    end
   end
 end

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -1,3 +1,4 @@
 class Pet < ApplicationRecord
   validates_presence_of :image, :name, :approximate_age, :sex, :current_shelter
+  belongs_to :shelter
 end

--- a/app/models/shelter.rb
+++ b/app/models/shelter.rb
@@ -1,3 +1,4 @@
 class Shelter < ApplicationRecord
   validates_presence_of :name, :address, :city, :state, :zip
+  has_many :pets
 end

--- a/app/views/pets/index.html.erb
+++ b/app/views/pets/index.html.erb
@@ -1,11 +1,13 @@
 <h1>All Pets</h1>
 
 <% @pets.each do |pet| %>
-  <ul>
-    <img src= <%= pet.image %>>
-    <li>Name: <%= pet.name %></li>
-    <li>Age: <%= pet.approximate_age %></li>
-    <li>Sex: <%= pet.sex %></li>
-    <li>Current Shelter: <%= pet.current_shelter %></li>
-  </ul>
+  <section id= 'pet-<%=pet.id%>'>
+    <ul>
+      <img src= <%= pet.image %>>
+      <li>Name: <%= pet.name %></li>
+      <li>Age: <%= pet.approximate_age %></li>
+      <li>Sex: <%= pet.sex %></li>
+      <li>Current Shelter: <%= pet.current_shelter %></li>
+    </ul>
+  </section>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,5 @@ Rails.application.routes.draw do
   delete '/shelters/:id', to: 'shelters#destroy'
 
   get '/pets', to: 'pets#index'
+  get '/shelters/:shelter_id/pets', to: 'pets#index'
 end

--- a/db/migrate/20191120024424_add_shelter_to_pets.rb
+++ b/db/migrate/20191120024424_add_shelter_to_pets.rb
@@ -1,0 +1,5 @@
+class AddShelterToPets < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :pets, :shelter, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191119180540) do
+ActiveRecord::Schema.define(version: 20191120024424) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,8 @@ ActiveRecord::Schema.define(version: 20191119180540) do
     t.string "current_shelter"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "shelter_id"
+    t.index ["shelter_id"], name: "index_pets_on_shelter_id"
   end
 
   create_table "shelters", force: :cascade do |t|
@@ -35,4 +37,5 @@ ActiveRecord::Schema.define(version: 20191119180540) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "pets", "shelters"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,6 +8,24 @@
 
 
 # Shelters
-shelter_1 = Shelter.create!(name: "Gimme Shelter", address: "5218 Rolling Stones Avenue", city: "Denver", state: "CO", zip: 80203)
-shelter_2 = Shelter.create!(name: "Boulder Bulldog Rescue", address: "2712 Slobber Circle", city: "Boulder", state: "CO", zip: 80205)
-shelter_3 = Shelter.create!(name: "Howlz 'n Jowlz", address: "7943 Furry Friend Drive", city: "Colorado Springs", state: "CO", zip: 80207)
+boulder_bulldog_rescue = Shelter.create(name: "Boulder Bulldog Rescue", address: "2712 Slobber Circle", city: "Boulder", state: "CO", zip: 80205)
+howlz_n_jowlz = Shelter.create(name: "Howlz 'n Jowlz", address: "7943 Furry Friend Drive", city: "Colorado Springs", state: "CO", zip: 80207)
+
+# Pets
+henri = boulder_bulldog_rescue.pets.create(image: "https://scontent-den4-1.xx.fbcdn.net/v/t1.0-9/69959835_377201229643201_4012713976726028288_o.jpg?_nc_cat=109&_nc_oc=AQlSsxr7ocJQdJ_USDptWwC1yYaFJvmQcqU1h1os4Kf4OXE8xOGfJWdUvVwrGyxSXYQ&_nc_ht=scontent-den4-1.xx&oh=b38ee308df03b9d760c5e720905eda0b&oe=5E4D6B16",
+                    name: 'Henri',
+                    approximate_age: 5,
+                    sex: 'Male',
+                    current_shelter: 'Boulder Bulldog Rescue')
+
+alfred = howlz_n_jowlz.pets.create(image: "https://scontent-den4-1.xx.fbcdn.net/v/t31.0-8/14608760_10153942326162816_2748710450820779939_o.jpg?_nc_cat=100&_nc_oc=AQnrfoKEaHR6I5dtefDwT7AGx_jSyJbGEabXvtbS9jMf2eGvl4_plvsK3eSmKjECppM&_nc_ht=scontent-den4-1.xx&oh=358dd965255af229bdc5ea8bb5090fca&oe=5E4AA5BB",
+                    name: 'Alfred',
+                    approximate_age: 2,
+                    sex: 'Male',
+                    current_shelter: "Howlz 'n Jowlz")
+
+toast = boulder_bulldog_rescue.pets.create(image: "https://i.pinimg.com/564x/4b/0c/99/4b0c99ace72fdfc65b2853fa14d41a8b.jpg",
+                    name: 'Toast',
+                    approximate_age: 4,
+                      sex: 'Female',
+                      current_shelter: "Boulder Bulldog Rescue")

--- a/spec/features/pets/index_spec.rb
+++ b/spec/features/pets/index_spec.rb
@@ -8,32 +8,34 @@ RSpec.describe "pets index page" do
     - approximate age
     - sex
     - name of the shelter where the pet is currently located" do
+      boulder_bulldog_rescue = Shelter.create(name: "Boulder Bulldog Rescue", address: "2712 Slobber Circle", city: "Boulder", state: "CO", zip: 80205)
+      howlz_n_jowlz = Shelter.create(name: "Howlz 'n Jowlz", address: "7943 Furry Friend Drive", city: "Colorado Springs", state: "CO", zip: 80207)
 
-      pet_1 = Pet.create(image: "https://scontent-den4-1.xx.fbcdn.net/v/t1.0-9/69959835_377201229643201_4012713976726028288_o.jpg?_nc_cat=109&_nc_oc=AQlSsxr7ocJQdJ_USDptWwC1yYaFJvmQcqU1h1os4Kf4OXE8xOGfJWdUvVwrGyxSXYQ&_nc_ht=scontent-den4-1.xx&oh=b38ee308df03b9d760c5e720905eda0b&oe=5E4D6B16",
+      henri = boulder_bulldog_rescue.pets.create(image: "https://scontent-den4-1.xx.fbcdn.net/v/t1.0-9/69959835_377201229643201_4012713976726028288_o.jpg?_nc_cat=109&_nc_oc=AQlSsxr7ocJQdJ_USDptWwC1yYaFJvmQcqU1h1os4Kf4OXE8xOGfJWdUvVwrGyxSXYQ&_nc_ht=scontent-den4-1.xx&oh=b38ee308df03b9d760c5e720905eda0b&oe=5E4D6B16",
                           name: 'Henri',
                           approximate_age: 5,
                           sex: 'Male',
                           current_shelter: 'Boulder Bulldog Rescue')
 
-      pet_2 = Pet.create(image: "https://scontent-den4-1.xx.fbcdn.net/v/t31.0-8/14608760_10153942326162816_2748710450820779939_o.jpg?_nc_cat=100&_nc_oc=AQnrfoKEaHR6I5dtefDwT7AGx_jSyJbGEabXvtbS9jMf2eGvl4_plvsK3eSmKjECppM&_nc_ht=scontent-den4-1.xx&oh=358dd965255af229bdc5ea8bb5090fca&oe=5E4AA5BB",
+      alfred = howlz_n_jowlz.pets.create(image: "https://scontent-den4-1.xx.fbcdn.net/v/t31.0-8/14608760_10153942326162816_2748710450820779939_o.jpg?_nc_cat=100&_nc_oc=AQnrfoKEaHR6I5dtefDwT7AGx_jSyJbGEabXvtbS9jMf2eGvl4_plvsK3eSmKjECppM&_nc_ht=scontent-den4-1.xx&oh=358dd965255af229bdc5ea8bb5090fca&oe=5E4AA5BB",
                           name: 'Alfred',
                           approximate_age: 2,
                           sex: 'Male',
                           current_shelter: "Howlz 'n Jowlz")
 
       visit '/pets'
-      
-      expect(page).to have_css("img[src*='#{pet_1.image}']")
-      expect(page).to have_content("Name: #{pet_1.name}")
-      expect(page).to have_content("Age: #{pet_1.approximate_age}")
-      expect(page).to have_content("Sex: #{pet_1.sex}")
-      expect(page).to have_content("Current Shelter: #{pet_1.current_shelter}")
 
-      expect(page).to have_css("img[src*='#{pet_2.image}']")
-      expect(page).to have_content("Name: #{pet_2.name}")
-      expect(page).to have_content("Age: #{pet_2.approximate_age}")
-      expect(page).to have_content("Sex: #{pet_2.sex}")
-      expect(page).to have_content("Current Shelter: #{pet_2.current_shelter}")
+      expect(page).to have_css("img[src*='#{henri.image}']")
+      expect(page).to have_content("Name: #{henri.name}")
+      expect(page).to have_content("Age: #{henri.approximate_age}")
+      expect(page).to have_content("Sex: #{henri.sex}")
+      expect(page).to have_content("Current Shelter: #{henri.current_shelter}")
+
+      expect(page).to have_css("img[src*='#{alfred.image}']")
+      expect(page).to have_content("Name: #{alfred.name}")
+      expect(page).to have_content("Age: #{alfred.approximate_age}")
+      expect(page).to have_content("Sex: #{alfred.sex}")
+      expect(page).to have_content("Current Shelter: #{alfred.current_shelter}")
     end
   end
 end

--- a/spec/features/pets/shelter_pets_index_spec.rb
+++ b/spec/features/pets/shelter_pets_index_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe "shelter pets index page" do
+  describe "as a visitor" do
+    it "I see each pet that can be adopted from that shelter with that shelter_id including the pet's:
+    - image
+    - name
+    - approximate age
+    - sex " do
+
+      shelter = Shelter.create!(name: "Boulder Bulldog Rescue", address: "2712 Slobber Circle", city: "Boulder", state: "CO", zip: 80205)
+      pet_1 = shelter.pets.create(image: "https://scontent-den4-1.xx.fbcdn.net/v/t1.0-9/69959835_377201229643201_4012713976726028288_o.jpg?_nc_cat=109&_nc_oc=AQlSsxr7ocJQdJ_USDptWwC1yYaFJvmQcqU1h1os4Kf4OXE8xOGfJWdUvVwrGyxSXYQ&_nc_ht=scontent-den4-1.xx&oh=b38ee308df03b9d760c5e720905eda0b&oe=5E4D6B16",
+                          name: 'Henri',
+                          approximate_age: 5,
+                          sex: 'Male',
+                          current_shelter: 'Boulder Bulldog Rescue')
+
+      pet_2 = shelter.pets.create(image: "https://scontent-den4-1.xx.fbcdn.net/v/t31.0-8/14608760_10153942326162816_2748710450820779939_o.jpg?_nc_cat=100&_nc_oc=AQnrfoKEaHR6I5dtefDwT7AGx_jSyJbGEabXvtbS9jMf2eGvl4_plvsK3eSmKjECppM&_nc_ht=scontent-den4-1.xx&oh=358dd965255af229bdc5ea8bb5090fca&oe=5E4AA5BB",
+                          name: 'Alfred',
+                          approximate_age: 2,
+                          sex: 'Male',
+                          current_shelter: "Howlz 'n Jowlz")
+
+      pet_3 = shelter.pets.create(image: "https://i.pinimg.com/564x/4b/0c/99/4b0c99ace72fdfc65b2853fa14d41a8b.jpg",
+                          name: 'Toast',
+                          approximate_age: 4,
+                          sex: 'Female',
+                          current_shelter: "Boulder Bulldog Rescue")
+
+      visit "/shelters/#{shelter.id}/pets"
+
+      within "#pet-#{pet_1.id}" do
+        expect(page).to have_css("img[src*='#{pet_1.image}']")
+        expect(page).to have_content(pet_1.name)
+        expect(page).to have_content(pet_1.approximate_age)
+        expect(page).to have_content(pet_1.sex)
+        expect(page).to have_content(pet_1.current_shelter)
+      end
+
+      within "#pet-#{pet_3.id}" do
+        expect(page).to have_css("img[src*='#{pet_3.image}']")
+        expect(page).to have_content(pet_3.name)
+        expect(page).to have_content(pet_3.approximate_age)
+        expect(page).to have_content(pet_3.sex)
+        expect(page).to have_content(pet_3.current_shelter)
+      end
+
+      expect(page).to_not have_css("img[src*='#{pet_2.image}']")
+      expect(page).to_not have_content(pet_2.name)
+      expect(page).to_not have_content(pet_2.approximate_age)
+      expect(page).to_not have_content(pet_2.sex)
+      expect(page).to_not have_content(pet_2.current_shelter)
+    end
+  end
+end

--- a/spec/features/pets/shelter_pets_index_spec.rb
+++ b/spec/features/pets/shelter_pets_index_spec.rb
@@ -8,26 +8,28 @@ RSpec.describe "shelter pets index page" do
     - approximate age
     - sex " do
 
-      shelter = Shelter.create!(name: "Boulder Bulldog Rescue", address: "2712 Slobber Circle", city: "Boulder", state: "CO", zip: 80205)
-      pet_1 = shelter.pets.create(image: "https://scontent-den4-1.xx.fbcdn.net/v/t1.0-9/69959835_377201229643201_4012713976726028288_o.jpg?_nc_cat=109&_nc_oc=AQlSsxr7ocJQdJ_USDptWwC1yYaFJvmQcqU1h1os4Kf4OXE8xOGfJWdUvVwrGyxSXYQ&_nc_ht=scontent-den4-1.xx&oh=b38ee308df03b9d760c5e720905eda0b&oe=5E4D6B16",
+      boulder_bulldog_rescue = Shelter.create(name: "Boulder Bulldog Rescue", address: "2712 Slobber Circle", city: "Boulder", state: "CO", zip: 80205)
+      howlz_n_jowlz = Shelter.create(name: "Howlz 'n Jowlz", address: "7943 Furry Friend Drive", city: "Colorado Springs", state: "CO", zip: 80207)
+
+      pet_1 = boulder_bulldog_rescue.pets.create(image: "https://scontent-den4-1.xx.fbcdn.net/v/t1.0-9/69959835_377201229643201_4012713976726028288_o.jpg?_nc_cat=109&_nc_oc=AQlSsxr7ocJQdJ_USDptWwC1yYaFJvmQcqU1h1os4Kf4OXE8xOGfJWdUvVwrGyxSXYQ&_nc_ht=scontent-den4-1.xx&oh=b38ee308df03b9d760c5e720905eda0b&oe=5E4D6B16",
                           name: 'Henri',
                           approximate_age: 5,
                           sex: 'Male',
                           current_shelter: 'Boulder Bulldog Rescue')
 
-      pet_2 = shelter.pets.create(image: "https://scontent-den4-1.xx.fbcdn.net/v/t31.0-8/14608760_10153942326162816_2748710450820779939_o.jpg?_nc_cat=100&_nc_oc=AQnrfoKEaHR6I5dtefDwT7AGx_jSyJbGEabXvtbS9jMf2eGvl4_plvsK3eSmKjECppM&_nc_ht=scontent-den4-1.xx&oh=358dd965255af229bdc5ea8bb5090fca&oe=5E4AA5BB",
+      pet_2 = howlz_n_jowlz.pets.create(image: "https://scontent-den4-1.xx.fbcdn.net/v/t31.0-8/14608760_10153942326162816_2748710450820779939_o.jpg?_nc_cat=100&_nc_oc=AQnrfoKEaHR6I5dtefDwT7AGx_jSyJbGEabXvtbS9jMf2eGvl4_plvsK3eSmKjECppM&_nc_ht=scontent-den4-1.xx&oh=358dd965255af229bdc5ea8bb5090fca&oe=5E4AA5BB",
                           name: 'Alfred',
                           approximate_age: 2,
                           sex: 'Male',
                           current_shelter: "Howlz 'n Jowlz")
 
-      pet_3 = shelter.pets.create(image: "https://i.pinimg.com/564x/4b/0c/99/4b0c99ace72fdfc65b2853fa14d41a8b.jpg",
+      pet_3 = boulder_bulldog_rescue.pets.create(image: "https://i.pinimg.com/564x/4b/0c/99/4b0c99ace72fdfc65b2853fa14d41a8b.jpg",
                           name: 'Toast',
                           approximate_age: 4,
-                          sex: 'Female',
-                          current_shelter: "Boulder Bulldog Rescue")
+                            sex: 'Female',
+                            current_shelter: "Boulder Bulldog Rescue")
 
-      visit "/shelters/#{shelter.id}/pets"
+      visit "/shelters/#{boulder_bulldog_rescue.id}/pets"
 
       within "#pet-#{pet_1.id}" do
         expect(page).to have_css("img[src*='#{pet_1.image}']")
@@ -44,11 +46,10 @@ RSpec.describe "shelter pets index page" do
         expect(page).to have_content(pet_3.sex)
         expect(page).to have_content(pet_3.current_shelter)
       end
-
+      
       expect(page).to_not have_css("img[src*='#{pet_2.image}']")
       expect(page).to_not have_content(pet_2.name)
       expect(page).to_not have_content(pet_2.approximate_age)
-      expect(page).to_not have_content(pet_2.sex)
       expect(page).to_not have_content(pet_2.current_shelter)
     end
   end

--- a/spec/models/pet_spec.rb
+++ b/spec/models/pet_spec.rb
@@ -8,4 +8,8 @@ describe Pet, type: :model do
     it {should validate_presence_of(:sex)}
     it {should validate_presence_of(:current_shelter)}
   end
+
+  describe "relationships" do
+    it {should belong_to :shelter}
+  end
 end

--- a/spec/models/shelter_spec.rb
+++ b/spec/models/shelter_spec.rb
@@ -8,4 +8,8 @@ describe Shelter, type: :model do
     it {should validate_presence_of(:state)}
     it {should validate_presence_of(:zip)}
   end
+
+  describe "relationships" do
+    it {should have_many(:pets)}
+  end
 end


### PR DESCRIPTION
* Add feature test for shelter pets index page
* Add model tests that pet belongs to a shelter and a shelter has many pets
* Establish one to many relationship between pet and shelter in models
* Create migration to add shelter id as foreign key on pets table 
* Migrate migration that adds shelter id as foreign key on pets table
* Change setup in feature test to reflect one to many relationship between pet and shelter
* Add another shelter to feature test to test that a shelter's pets index only shows the pets for that shelter
* Add route for shelter pets index
* Change index method in pets controller to reflect that the view can display either all the pets or just the pets for a certain shelter
* Add CSS id for each pet
* All tests passing