### PR TITLE
Shelter links refactor

### DIFF
--- a/app/views/pets/index.html.erb
+++ b/app/views/pets/index.html.erb
@@ -10,7 +10,7 @@
       <% if @shelter %>
         <p><%= link_to "Edit #{pet.name}", "/shelters/#{pet.shelter.id}/pets/#{pet.id}/edit" %></p>
       <% else %>
-        <li>Current Shelter: <%= link_to "#{pet.shelter.name}" %></li>
+        <li>Current Shelter: <%= link_to "#{pet.shelter.name}", "/shelters/#{pet.shelter.id}" %></li>
         <p><%= link_to "Edit #{pet.name}", "/pets/#{pet.id}/edit" %></p>
       <% end %>
       <p><%= link_to "Delete #{pet.name}", "/pets/#{pet.id}", method: :delete %></p>

--- a/spec/features/pets/index_spec.rb
+++ b/spec/features/pets/index_spec.rb
@@ -36,6 +36,11 @@ RSpec.describe "pets index page" do
         expect(page).to have_link("#{@henri.shelter.name}")
       end
 
+      click_link "#{@henri.shelter.name}"
+      expect(current_path).to eq("/shelters/#{@boulder_bulldog_rescue.id}")
+
+      visit '/pets'
+
       within "#pet-#{@alfred.id}" do
         expect(page).to have_css("img[src*='#{@alfred.image}']")
         expect(page).to have_content("Name: #{@alfred.name}")
@@ -44,6 +49,9 @@ RSpec.describe "pets index page" do
         expect(page).to have_content("Current Shelter: #{@alfred.shelter.name}")
         expect(page).to have_link("#{@alfred.shelter.name}")
       end
+
+      click_link "#{@alfred.shelter.name}"
+      expect(current_path).to eq("/shelters/#{@howlz_n_jowlz.id}")
     end
 
     it "I see an edit link next to each pet that allows me to edit that pet's information through the edit form" do

--- a/spec/features/shelters/index_spec.rb
+++ b/spec/features/shelters/index_spec.rb
@@ -9,10 +9,13 @@ describe "shelter index page" do
 
       visit '/shelters'
     end
-    it "I see the name of each shelter in the system" do
+    it "I see the name of each shelter in the system as a link to the shelter's show page" do
       expect(page).to have_link(@shelter_1.name)
       expect(page).to have_link(@shelter_2.name)
       expect(page).to have_link(@shelter_3.name)
+
+      click_on "#{@shelter_3.name}"
+      expect(current_path).to eq("/shelters/#{@shelter_3.id}")
     end
 
     it "I see an edit link next to each shelter that allows me to edit the shelter through the edit form" do


### PR DESCRIPTION
* Add tests to shelter index and pets index that clicking on a shelter's name navigates to shelter's show page
* Refactor line in view so that link navigates to shelter's show page instead of remaining on pets index
* All tests passing