### PR TITLE
Adoptable pets display first

### DIFF
--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -2,9 +2,9 @@ class PetsController < ApplicationController
   def index
     if params[:shelter_id]
       @shelter = Shelter.find(params[:shelter_id])
-      @pets = @shelter.pets
+      @pets = @shelter.pets.sort_pets_by_status
     else
-      @pets = Pet.all
+      @pets = Pet.all.sort_pets_by_status
     end
   end
 

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -6,4 +6,8 @@ class Pet < ApplicationRecord
                          :description
   validates_inclusion_of :adoptable?, :in => [true, false]
   belongs_to :shelter
+
+  def self.sort_pets_by_status
+    Pet.order(adoptable?: :desc)
+  end
 end

--- a/app/views/pets/index.html.erb
+++ b/app/views/pets/index.html.erb
@@ -5,24 +5,26 @@
 <% end %>
 
 <% @pets.each do |pet| %>
-  <section id= 'pet-<%=pet.id%>'>
-    <ul>
-      <img src= <%= pet.image %>>
-      <% if @shelter %>
-        <li>Name: <%= link_to "#{pet.name}", "/shelters/#{pet.shelter.id}/pets/#{pet.id}" %></li>
-      <% else %>
-        <li>Name: <%= link_to "#{pet.name}", "/pets/#{pet.id}" %></li>
-      <% end %>
-      <li>Age: <%= pet.approximate_age %></li>
-      <li>Sex: <%= pet.sex %></li>
-      <% if @shelter %>
-        <p><%= link_to "Edit", "/shelters/#{pet.shelter.id}/pets/#{pet.id}/edit" %>  <%= pet.name %></p>
-      <% else %>
-        <li>Current Shelter: <%= link_to "#{pet.shelter.name}", "/shelters/#{pet.shelter.id}" %></li>
-        <p><%= link_to "Edit", "/pets/#{pet.id}/edit" %> <%= pet.name %></p>
-      <% end %>
-      <p><%= link_to "Delete", "/pets/#{pet.id}", method: :delete %> <%= pet.name %></p>
-    </ul>
+  <section class = "pets">
+    <section id= 'pet-<%=pet.id%>'>
+      <ul>
+        <img src= <%= pet.image %>>
+        <% if @shelter %>
+          <li>Name: <%= link_to "#{pet.name}", "/shelters/#{pet.shelter.id}/pets/#{pet.id}" %></li>
+        <% else %>
+          <li>Name: <%= link_to "#{pet.name}", "/pets/#{pet.id}" %></li>
+        <% end %>
+        <li>Age: <%= pet.approximate_age %></li>
+        <li>Sex: <%= pet.sex %></li>
+        <% if @shelter %>
+          <p><%= link_to "Edit", "/shelters/#{pet.shelter.id}/pets/#{pet.id}/edit" %>  <%= pet.name %></p>
+        <% else %>
+          <li>Current Shelter: <%= link_to "#{pet.shelter.name}", "/shelters/#{pet.shelter.id}" %></li>
+          <p><%= link_to "Edit", "/pets/#{pet.id}/edit" %> <%= pet.name %></p>
+        <% end %>
+        <p><%= link_to "Delete", "/pets/#{pet.id}", method: :delete %> <%= pet.name %></p>
+      </ul>
+    </section>
   </section>
 <% end %>
 

--- a/app/views/pets/show.html.erb
+++ b/app/views/pets/show.html.erb
@@ -8,7 +8,7 @@
   <% if @pet.adoptable? %>
     <li>Status: Adoptable </li>
   <% else %>
-    <li>Status: Not Adoptable </li>
+    <li>Status: Adoption Pending </li>
   <% end %>
 </ul>
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,6 +12,20 @@ boulder_bulldog_rescue = Shelter.create(name: "Boulder Bulldog Rescue", address:
 howlz_n_jowlz = Shelter.create(name: "Howlz 'n Jowlz", address: "7943 Furry Friend Drive", city: "Colorado Springs", state: "CO", zip: 80207)
 
 # Pets
+harry = boulder_bulldog_rescue.pets.create(image: "https://i.pinimg.com/564x/aa/38/27/aa38272dbdb0b6ee03c17420b7de3c2c.jpg",
+  name: 'Harry',
+  description: "Underbite for days.",
+  approximate_age: 6,
+  sex: 'Male',
+  adoptable?: false)
+
+tater_tot = boulder_bulldog_rescue.pets.create(image: "https://i.pinimg.com/564x/ac/4c/3f/ac4c3f848136a5f59b973943c113723f.jpg",
+    name: 'Tater Tot',
+    description: "The cutest potato!",
+    approximate_age: 8,
+    sex: 'Male',
+    adoptable?: false)
+    
 henri = boulder_bulldog_rescue.pets.create(image: "https://scontent-den4-1.xx.fbcdn.net/v/t1.0-9/69959835_377201229643201_4012713976726028288_o.jpg?_nc_cat=109&_nc_oc=AQlSsxr7ocJQdJ_USDptWwC1yYaFJvmQcqU1h1os4Kf4OXE8xOGfJWdUvVwrGyxSXYQ&_nc_ht=scontent-den4-1.xx&oh=b38ee308df03b9d760c5e720905eda0b&oe=5E4D6B16",
                     name: 'Henri',
                     description: "With his heartwarming wrinkles and furrowed brow, he'll slobber his way into your heart!",

--- a/spec/features/pets/index_spec.rb
+++ b/spec/features/pets/index_spec.rb
@@ -6,6 +6,13 @@ RSpec.describe "pets index page" do
       @boulder_bulldog_rescue = Shelter.create(name: "Boulder Bulldog Rescue", address: "2712 Slobber Circle", city: "Boulder", state: "CO", zip: 80205)
       @howlz_n_jowlz = Shelter.create(name: "Howlz 'n Jowlz", address: "7943 Furry Friend Drive", city: "Colorado Springs", state: "CO", zip: 80207)
 
+      @botox = @boulder_bulldog_rescue.pets.create(image: "https://slack-imgs.com/?c=1&o1=ro&url=https%3A%2F%2Fi.pinimg.com%2F564x%2Fc4%2F3e%2F7f%2Fc43e7f6a45aba8790a8c47d3a5d62ee8.jpg",
+        name: 'Botox',
+        description: 'So wrinkly!',
+        approximate_age: 7,
+        sex: 'Female',
+        adoptable?: false)
+
       @henri = @boulder_bulldog_rescue.pets.create(image: "https://scontent-den4-1.xx.fbcdn.net/v/t1.0-9/69959835_377201229643201_4012713976726028288_o.jpg?_nc_cat=109&_nc_oc=AQlSsxr7ocJQdJ_USDptWwC1yYaFJvmQcqU1h1os4Kf4OXE8xOGfJWdUvVwrGyxSXYQ&_nc_ht=scontent-den4-1.xx&oh=b38ee308df03b9d760c5e720905eda0b&oe=5E4D6B16",
         name: 'Henri',
         description: "With his heartwarming wrinkles and furrowed brow, he'll slobber his way into your heart!",
@@ -17,6 +24,19 @@ RSpec.describe "pets index page" do
         description: "Truly a beautiful wrinkly boi!",
         approximate_age: 2,
         sex: 'Male')
+
+      @pumbaa = @boulder_bulldog_rescue.pets.create!(image: "https://slack-imgs.com/?c=1&o1=ro&url=https%3A%2F%2Fi.pinimg.com%2F564x%2Fc4%2F3e%2F7f%2Fc43e7f6a45aba8790a8c47d3a5d62ee8.jpg",
+        name: 'Pumbaa',
+        description: 'So wrinkly!',
+        approximate_age: 3,
+        sex: 'Male',
+        adoptable?: false)
+
+      @winston = @howlz_n_jowlz.pets.create!(image: "https://scontent-den4-1.xx.fbcdn.net/v/t31.0-8/14608760_10153942326162816_2748710450820779939_o.jpg?_nc_cat=100&_nc_oc=AQnrfoKEaHR6I5dtefDwT7AGx_jSyJbGEabXvtbS9jMf2eGvl4_plvsK3eSmKjECppM&_nc_ht=scontent-den4-1.xx&oh=358dd965255af229bdc5ea8bb5090fca&oe=5E4AA5BB",
+          name: 'Winston',
+          description: "Truly a beautiful wrinkly boi!",
+          approximate_age: 8,
+          sex: 'Male')
 
       visit '/pets'
     end
@@ -35,8 +55,6 @@ RSpec.describe "pets index page" do
         expect(page).to have_content("Current Shelter: #{@henri.shelter.name}")
       end
 
-      visit '/pets'
-
       within "#pet-#{@alfred.id}" do
         expect(page).to have_css("img[src*='#{@alfred.image}']")
         expect(page).to have_content("Name: #{@alfred.name}")
@@ -44,24 +62,41 @@ RSpec.describe "pets index page" do
         expect(page).to have_content("Sex: #{@alfred.sex}")
         expect(page).to have_content("Current Shelter: #{@alfred.shelter.name}")
       end
+
+      within "#pet-#{@botox.id}" do
+        expect(page).to have_css("img[src*='#{@botox.image}']")
+        expect(page).to have_content("Name: #{@botox.name}")
+        expect(page).to have_content("Age: #{@botox.approximate_age}")
+        expect(page).to have_content("Sex: #{@botox.sex}")
+        expect(page).to have_content("Current Shelter: #{@botox.shelter.name}")
+      end
     end
 
     it "I can click on the the name of the pet's shelter and navigate to that shelter's show page" do
       within "#pet-#{@henri.id}" do
         expect(page).to have_link("#{@henri.shelter.name}")
+        click_link "#{@henri.shelter.name}"
       end
 
-      click_link "#{@henri.shelter.name}"
       expect(current_path).to eq("/shelters/#{@boulder_bulldog_rescue.id}")
 
       visit '/pets'
 
       within "#pet-#{@alfred.id}" do
         expect(page).to have_link("#{@alfred.shelter.name}")
+        click_link "#{@alfred.shelter.name}"
       end
 
-      click_link "#{@alfred.shelter.name}"
       expect(current_path).to eq("/shelters/#{@howlz_n_jowlz.id}")
+
+      visit '/pets'
+
+      within "#pet-#{@botox.id}" do
+        expect(page).to have_link("#{@botox.shelter.name}")
+        click_link "#{@botox.shelter.name}"
+      end
+
+      expect(current_path).to eq("/shelters/#{@boulder_bulldog_rescue.id}")
     end
 
     it "I can click on the the name of the pet and navigate to that pet's show page" do
@@ -78,6 +113,14 @@ RSpec.describe "pets index page" do
       end
 
       expect(current_path).to eq("/pets/#{@alfred.id}")
+
+      visit '/pets'
+
+      within "#pet-#{@botox.id}" do
+        click_link "#{@botox.name}"
+      end
+
+      expect(current_path).to eq("/pets/#{@botox.id}")
     end
 
     it "I see an edit link next to each pet that allows me to edit that pet's information through the edit form" do
@@ -92,6 +135,13 @@ RSpec.describe "pets index page" do
         click_link "Edit"
       end
       expect(current_path).to eq("/pets/#{@alfred.id}/edit")
+
+      visit '/pets'
+
+      within "#pet-#{@botox.id}" do
+        click_link "Edit"
+      end
+      expect(current_path).to eq("/pets/#{@botox.id}/edit")
     end
 
     it "I see a delete link next to each pet that allows me to delete that pet" do
@@ -108,6 +158,22 @@ RSpec.describe "pets index page" do
       end
       expect(current_path).to eq("/pets")
       expect(page).to_not have_content(@alfred.name)
+
+      visit '/pets'
+
+      within "#pet-#{@botox.id}" do
+        click_link "Delete"
+      end
+      expect(current_path).to eq("/pets")
+      expect(page).to_not have_content(@botox.name)
+    end
+
+    it "I see adoptable pets listed before pets whose adoption status is pending" do
+      expect(page.find_all('.pets')[0]).to have_content("#{@henri.name}")
+      expect(page.find_all('.pets')[1]).to have_content("#{@alfred.name}")
+      expect(page.find_all('.pets')[2]).to have_content("#{@winston.name}")
+      expect(page.find_all('.pets')[3]).to have_content("#{@botox.name}")
+      expect(page.find_all('.pets')[4]).to have_content("#{@pumbaa.name}")
     end
   end
 end

--- a/spec/features/pets/shelter_pets_index_spec.rb
+++ b/spec/features/pets/shelter_pets_index_spec.rb
@@ -24,6 +24,26 @@ RSpec.describe "shelter pets index page" do
         approximate_age: 4,
         sex: 'Female')
 
+      @pet_4= @boulder_bulldog_rescue.pets.create(image: "https://slack-imgs.com/?c=1&o1=ro&url=https%3A%2F%2Fi.pinimg.com%2F564x%2Fc4%2F3e%2F7f%2Fc43e7f6a45aba8790a8c47d3a5d62ee8.jpg",
+        name: 'Botox',
+        description: 'So wrinkly!',
+        approximate_age: 7,
+        sex: 'Female',
+        adoptable?: false)
+
+      @pet_5 = @boulder_bulldog_rescue.pets.create!(image: "https://i.pinimg.com/564x/fa/f0/f1/faf0f151c420f2451bcd583de153c38b.jpg",
+        name: 'Pumbaa',
+        description: 'So wrinkly!',
+        approximate_age: 3,
+        sex: 'Male',
+        adoptable?: false)
+
+      @pet_6 = @boulder_bulldog_rescue.pets.create!(image: "https://i.pinimg.com/564x/07/34/10/0734102786dfa61651d5378a17476af6.jpg",
+          name: 'Winston',
+          description: "Truly a beautiful wrinkly boi!",
+          approximate_age: 8,
+          sex: 'Male')
+
       visit "/shelters/#{@boulder_bulldog_rescue.id}/pets"
     end
 
@@ -106,7 +126,15 @@ RSpec.describe "shelter pets index page" do
     end
 
     it "I see a count of the number of pets at this shelter" do
-      expect(page).to have_content("Number of Pets at #{@boulder_bulldog_rescue.name}: 2")
+      expect(page).to have_content("Number of Pets at #{@boulder_bulldog_rescue.name}: 5")
+    end
+
+    it "I see adoptable pets listed before pets whose adoption status is pending" do
+      expect(page.find_all('.pets')[0]).to have_content("#{@pet_1.name}")
+      expect(page.find_all('.pets')[1]).to have_content("#{@pet_3.name}")
+      expect(page.find_all('.pets')[2]).to have_content("#{@pet_6.name}")
+      expect(page.find_all('.pets')[3]).to have_content("#{@pet_4.name}")
+      expect(page.find_all('.pets')[4]).to have_content("#{@pet_5.name}")
     end
   end
 end

--- a/spec/models/pet_spec.rb
+++ b/spec/models/pet_spec.rb
@@ -13,4 +13,46 @@ describe Pet, type: :model do
   describe "relationships" do
     it {should belong_to :shelter}
   end
+
+  describe "class methods" do
+    it ".sort_pets_by_status" do
+      boulder_bulldog_rescue = Shelter.create(name: "Boulder Bulldog Rescue", address: "2712 Slobber Circle", city: "Boulder", state: "CO", zip: 80205)
+      howlz_n_jowlz = Shelter.create(name: "Howlz 'n Jowlz", address: "7943 Furry Friend Drive", city: "Colorado Springs", state: "CO", zip: 80207)
+
+      botox = boulder_bulldog_rescue.pets.create(image: "https://slack-imgs.com/?c=1&o1=ro&url=https%3A%2F%2Fi.pinimg.com%2F564x%2Fc4%2F3e%2F7f%2Fc43e7f6a45aba8790a8c47d3a5d62ee8.jpg",
+        name: 'Botox',
+        description: 'So wrinkly!',
+        approximate_age: 7,
+        sex: 'Female',
+        adoptable?: false)
+
+      pumbaa = boulder_bulldog_rescue.pets.create(image: "https://slack-imgs.com/?c=1&o1=ro&url=https%3A%2F%2Fi.pinimg.com%2F564x%2Fc4%2F3e%2F7f%2Fc43e7f6a45aba8790a8c47d3a5d62ee8.jpg",
+        name: 'Pumbaa',
+        description: 'So wrinkly!',
+        approximate_age: 3,
+        sex: 'Male',
+        adoptable?: false)
+
+      henri = boulder_bulldog_rescue.pets.create(image: "https://scontent-den4-1.xx.fbcdn.net/v/t1.0-9/69959835_377201229643201_4012713976726028288_o.jpg?_nc_cat=109&_nc_oc=AQlSsxr7ocJQdJ_USDptWwC1yYaFJvmQcqU1h1os4Kf4OXE8xOGfJWdUvVwrGyxSXYQ&_nc_ht=scontent-den4-1.xx&oh=b38ee308df03b9d760c5e720905eda0b&oe=5E4D6B16",
+        name: 'Henri',
+        description: "With his heartwarming wrinkles and furrowed brow, he'll slobber his way into your heart!",
+        approximate_age: 5,
+        sex: 'Male')
+
+      alfred = howlz_n_jowlz.pets.create(image: "https://scontent-den4-1.xx.fbcdn.net/v/t31.0-8/14608760_10153942326162816_2748710450820779939_o.jpg?_nc_cat=100&_nc_oc=AQnrfoKEaHR6I5dtefDwT7AGx_jSyJbGEabXvtbS9jMf2eGvl4_plvsK3eSmKjECppM&_nc_ht=scontent-den4-1.xx&oh=358dd965255af229bdc5ea8bb5090fca&oe=5E4AA5BB",
+        name: 'Alfred',
+        description: "Truly a beautiful wrinkly boi!",
+        approximate_age: 2,
+        sex: 'Male')
+
+      winston = howlz_n_jowlz.pets.create(image: "https://scontent-den4-1.xx.fbcdn.net/v/t31.0-8/14608760_10153942326162816_2748710450820779939_o.jpg?_nc_cat=100&_nc_oc=AQnrfoKEaHR6I5dtefDwT7AGx_jSyJbGEabXvtbS9jMf2eGvl4_plvsK3eSmKjECppM&_nc_ht=scontent-den4-1.xx&oh=358dd965255af229bdc5ea8bb5090fca&oe=5E4AA5BB",
+        name: 'Winston',
+        description: "Truly a beautiful wrinkly boi!",
+        approximate_age: 8,
+        sex: 'Male')
+
+      expected = [henri, alfred, winston, botox, pumbaa]
+      expect(Pet.sort_pets_by_status).to eq(expected)
+    end
+  end
 end


### PR DESCRIPTION
* Add feature tests that adoptable pets are displayed before pets whose adoption status is pending (on pets index and shelter pets index)
* Add model test for sort_pets_by_status class method
* Wrap pets in a section and assign a class id on pets index page
* Add sort_pets_by_status method in Pet model
* Update index method in PetsController to call on sort_pets_by_status model method
* Change false adoptable? status to say "Adoption Pending" instead of "Not Adoptable" in the view
* Create pets whose adoption status is pending in seeds file
* All tests passing